### PR TITLE
add option to specify user agent header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 pylinkchecker.egg-info
 dist
 .idea/
+build/

--- a/pylinkchecker/crawler.py
+++ b/pylinkchecker/crawler.py
@@ -268,7 +268,7 @@ class PageCrawler(object):
         try:
             response = open_url(self.urlopen, self.request_class,
                     url_split_to_crawl.geturl(), self.worker_config.timeout,
-                    self.timeout_exception, self.auth_header)
+                    self.timeout_exception, self.worker_config.user_agent, self.auth_header)
 
             if response.exception:
                 if response.status:
@@ -497,7 +497,7 @@ def crawl_page(worker_init):
     page_crawler.crawl_page_forever()
 
 
-def open_url(open_func, request_class, url, timeout, timeout_exception,
+def open_url(open_func, request_class, url, timeout, timeout_exception, user_agent,
         auth_header=None):
     """Opens a URL and returns a Response object.
 
@@ -514,7 +514,11 @@ def open_url(open_func, request_class, url, timeout, timeout_exception,
     :rtype: A Response object
     """
     try:
-        request = request_class(url)
+	request = None
+	if user_agent:
+            request = request_class(url,headers={'User-Agent': user_agent})
+	else:
+            request = request_class(url)
         if auth_header:
             request.add_header(auth_header[0], auth_header[1])
         output_value = open_func(request, timeout=timeout)

--- a/pylinkchecker/models.py
+++ b/pylinkchecker/models.py
@@ -83,7 +83,7 @@ WorkerInit = namedtuple("WorkerInit", ["worker_config", "input_queue",
 
 
 WorkerConfig = namedtuple("WorkerConfig", ["username", "password", "types",
-        "timeout", "parser", "strict_mode"])
+        "timeout", "parser", "strict_mode", "user_agent"])
 
 
 WorkerInput = namedtuple("WorkerInput", ["url_split", "should_crawl"])
@@ -213,7 +213,7 @@ class Config(UTF8Class):
                         .format(element_type))
 
         return WorkerConfig(options.username, options.password, types,
-                options.timeout, options.parser, options.strict_mode)
+                options.timeout, options.parser, options.strict_mode, options.user_agent)
 
     def _build_accepted_hosts(self, options, start_urls):
         hosts = set()
@@ -243,6 +243,9 @@ class Config(UTF8Class):
 
         crawler_group = OptionGroup(parser, "Crawler Options",
                 "These options modify the way the crawler traverses the site.")
+        crawler_group.add_option("-A", "--user-agent", dest="user_agent", 
+                action="store", default=None,
+                help="Specify the user agent header when crawling sites. Default is \"Python-urllib/X.X\"")
         crawler_group.add_option("-O", "--test-outside", dest="test_outside",
                 action="store_true", default=False,
                 help="fetch resources from other domains without crawling them")


### PR DESCRIPTION
some websites are performing user agent verification checks and returning http 403 when the link is ok. 